### PR TITLE
Fix/no data object

### DIFF
--- a/pkg/pdfcpu/parse.go
+++ b/pkg/pdfcpu/parse.go
@@ -750,7 +750,8 @@ func parseBooleanOrNull(l string) (val Object, s string, ok bool) {
 func parseObject(line *string) (Object, error) {
 
 	if noBuf(line) {
-		return nil, errBufNotAvailable
+		// only whitespace returns empty StringLiteral
+		return StringLiteral(""), nil
 	}
 
 	l := *line

--- a/pkg/pdfcpu/parse.go
+++ b/pkg/pdfcpu/parse.go
@@ -760,8 +760,8 @@ func parseObject(line *string) (Object, error) {
 	// position to first non whitespace char
 	l, _ = trimLeftSpace(l)
 	if len(l) == 0 {
-		// only whitespace
-		return nil, errBufNotAvailable
+		// only whitespace returns empty StringLiteral
+		return StringLiteral(""), nil
 	}
 
 	var value Object

--- a/pkg/pdfcpu/parse_common_test.go
+++ b/pkg/pdfcpu/parse_common_test.go
@@ -109,5 +109,8 @@ func TestParseObject(t *testing.T) {
 	doTestParseObjectOK("1 0 R%comment\x0a", t)
 	doTestParseObjectOK("[1 0 R /n 2 0 R]", t)
 	doTestParseObjectOK("<</n 1 0 R>>", t)
+
+	doTestParseObjectOK("    ", t)
+	doTestParseObjectOK("    \n", t)
 	doTestParseObjectOK("\n", t)
 }

--- a/pkg/pdfcpu/parse_common_test.go
+++ b/pkg/pdfcpu/parse_common_test.go
@@ -109,4 +109,5 @@ func TestParseObject(t *testing.T) {
 	doTestParseObjectOK("1 0 R%comment\x0a", t)
 	doTestParseObjectOK("[1 0 R /n 2 0 R]", t)
 	doTestParseObjectOK("<</n 1 0 R>>", t)
+	doTestParseObjectOK("\n", t)
 }

--- a/pkg/pdfcpu/parse_common_test.go
+++ b/pkg/pdfcpu/parse_common_test.go
@@ -110,6 +110,7 @@ func TestParseObject(t *testing.T) {
 	doTestParseObjectOK("[1 0 R /n 2 0 R]", t)
 	doTestParseObjectOK("<</n 1 0 R>>", t)
 
+	doTestParseObjectOK("", t)
 	doTestParseObjectOK("    ", t)
 	doTestParseObjectOK("    \n", t)
 	doTestParseObjectOK("\n", t)


### PR DESCRIPTION
下記のようにデータが何もない`Object`をパースするとエラーになっていたので、
空の`StringLiteral`を返すように変更した。

```
13 0 obj
endobj
```

PDF仕様ではこんなデータはないのですが、`Acrobat`とかで開けるので対応しました。
`ImageMagick`が作ったファイルっぽい。